### PR TITLE
Enable monitoring.googleapis.com

### DIFF
--- a/gcp/configuration/roles.tf
+++ b/gcp/configuration/roles.tf
@@ -16,7 +16,8 @@ locals {
     "compute.admin",
     "compute.networkAdmin",
     "certificatemanager.owner",
-    "cloudsql.admin"
+    "cloudsql.admin",
+    "monitoring.admin"
   ]
 
   dataplane_iam_role_bindings = [

--- a/gcp/configuration/services.tf
+++ b/gcp/configuration/services.tf
@@ -16,7 +16,8 @@ locals {
     "compute.googleapis.com",
     "certificatemanager.googleapis.com",
     "servicenetworking.googleapis.com",
-    "aiplatform.googleapis.com"
+    "aiplatform.googleapis.com",
+    "monitoring.googleapis.com"
   ]
 }
 


### PR DESCRIPTION
Required for DB Monitoring