### PR TITLE
Update IAM permissions to allow tasks to read secrets directly

### DIFF
--- a/aws/configuration/roles.tf
+++ b/aws/configuration/roles.tf
@@ -48,15 +48,6 @@ resource "aws_iam_role_policy" "execution" {
 
       {
         Effect = "Allow"
-        Action = ["secretsmanager:GetSecretValue", "secretsmanager:GetRandomPassword"]
-        Resource = [
-          aws_secretsmanager_secret.ingest_basic_auth.arn,
-          aws_secretsmanager_secret.query_basic_auth.arn,
-        ]
-      },
-
-      {
-        Effect = "Allow"
         Action = [
           "servicediscovery:RegisterInstance",
           "servicediscovery:DeregisterInstance",
@@ -125,6 +116,19 @@ resource "aws_iam_role_policy" "task" {
           [data.aws_arn.catalog.arn, aws_glue_catalog_database.iceberg.arn],
           [for _, table in aws_glue_catalog_table.iceberg : table.arn],
         )
+      },
+      
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue", 
+          "secretsmanager:GetRandomPassword",
+          "secretsmanager:ListSecretVersionIds"
+        ]
+        Resource = [
+          aws_secretsmanager_secret.ingest_basic_auth.arn,
+          aws_secretsmanager_secret.query_basic_auth.arn,
+        ]
       },
     ]
   })

--- a/gcp/configuration/roles.tf
+++ b/gcp/configuration/roles.tf
@@ -23,7 +23,7 @@ locals {
   dataplane_iam_role_bindings = [
     "logging.logWriter",
     "storage.admin",
-    "secretmanager.secretAccessor",
+    "secretmanager.secretVersionAccessor",
     "aiplatform.user"
   ]
 }

--- a/gcp/configuration/roles.tf
+++ b/gcp/configuration/roles.tf
@@ -23,7 +23,7 @@ locals {
   dataplane_iam_role_bindings = [
     "logging.logWriter",
     "storage.admin",
-    "secretmanager.secretVersionAccessor",
+    "secretmanager.viewer",
     "aiplatform.user"
   ]
 }

--- a/gcp/configuration/roles.tf
+++ b/gcp/configuration/roles.tf
@@ -24,6 +24,7 @@ locals {
     "logging.logWriter",
     "storage.admin",
     "secretmanager.viewer",
+    "secretmanager.secretAccessor",
     "aiplatform.user"
   ]
 }


### PR DESCRIPTION
This change is intended to allow firetiger services to read secret values used for basic http authentication in order to support secret rotation.
