### PR TITLE
fix: write.data.location => write.data.path

### DIFF
--- a/iceberg/table_metadata/table_metadata.tf
+++ b/iceberg/table_metadata/table_metadata.tf
@@ -22,7 +22,7 @@ locals {
   }
 
   properties = merge(local.default_properties, var.properties, {
-    "write.data.location" = format("%s/%s/data", var.bucket, var.table)
+    "write.data.path" = format("%s/%s/data", var.bucket, var.table)
   })
 }
 


### PR DESCRIPTION
This is causing tables we deployed to be missing the `/data` prefix for data files.