### PR TITLE
Support regional deployments

### DIFF
--- a/examples/aws/cloudwatch/logs/main.tf
+++ b/examples/aws/cloudwatch/logs/main.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 # Deploy the Firetiger CloudWatch Logs integration module

--- a/ingest/aws/cloudwatch/logs/terraform/variables.tf
+++ b/ingest/aws/cloudwatch/logs/terraform/variables.tf
@@ -66,3 +66,4 @@ variable "log_retention_days" {
     error_message = "Log retention days must be one of: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653."
   }
 }
+


### PR DESCRIPTION
Allow users to configure the region of deployment - this includes pulling resources from firetiger's regional public buckets