### PR TITLE
ci: auto-tag main with YYYY.M.D-{sha7} on every merge

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -38,6 +38,8 @@ jobs:
             echo "Tag ${VERSION} already exists, skipping"
             exit 0
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${VERSION}" -m "Release ${VERSION}" "$GITHUB_SHA"
           git push origin "refs/tags/${VERSION}"
 

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,57 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: tag-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        run: |
+          DATE=$(date -u +%Y.%-m.%-d)
+          SHA=$(git rev-parse --short=6 "$GITHUB_SHA")
+          VERSION="${DATE}-${SHA}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Computed version '$VERSION' is not valid SemVer"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if git rev-parse --verify --quiet "refs/tags/${VERSION}"; then
+            echo "Tag ${VERSION} already exists, skipping"
+            exit 0
+          fi
+          git tag -a "${VERSION}" -m "Release ${VERSION}" "$GITHUB_SHA"
+          git push origin "refs/tags/${VERSION}"
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          {
+            echo "## Tagged \`${VERSION}\`"
+            echo ""
+            echo "Pin a module in terraform:"
+            echo ""
+            echo '```hcl'
+            echo "module \"firetiger_cloudwatch_logs\" {"
+            echo "  source = \"github.com/firetiger-inc/public//ingest/aws/cloudwatch/logs/terraform?ref=${VERSION}\""
+            echo "}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -23,7 +23,7 @@ jobs:
         id: version
         run: |
           DATE=$(date -u +%Y.%-m.%-d)
-          SHA=$(git rev-parse --short=6 "$GITHUB_SHA")
+          SHA=$(git rev-parse --short=7 "$GITHUB_SHA")
           VERSION="${DATE}-${SHA}"
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
             echo "::error::Computed version '$VERSION' is not valid SemVer"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/tag.yaml` — runs on every push to `main` (i.e. PR merges) and creates an annotated git tag `YYYY.M.D-{sha7}` (e.g. `2026.5.5-a596907`) pointing at the merge SHA.
- Same CalVer scheme as core's `ci.yaml` `publish-chart` job (which uses `cut -c1-7` on the commit SHA); the commit-SHA suffix is deterministic so we don't need to query existing tags to disambiguate same-day releases.
- Idempotent (skips if tag exists), serialized via `concurrency: tag-main`, configures the `github-actions[bot]` git identity before tagging, and validated against the SemVer regex `^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$`.

## Why

Today every example references modules with `?ref=main`, so consumers re-pull the latest commit on every apply with no way to pin. Auto-tagging on merge gives consumers a stable ref like:

```hcl
module "firetiger_cloudwatch_logs" {
  source = "github.com/firetiger-inc/public//ingest/aws/cloudwatch/logs/terraform?ref=2026.5.5-a596907"
}
```

Tags every push to `main` (no path filter) — cheap (no build, just a tag), but accumulates fast. Easy to add `paths:` filters later if it becomes noisy.

## Test plan

- [ ] Merge this PR and confirm the workflow runs.
- [ ] Verify a tag matching `YYYY.M.D-[0-9a-f]{7}` appears at https://github.com/firetiger-inc/public/tags pointing at the merge commit.
- [ ] Check the run summary shows the copy-pasteable terraform `?ref=` snippet.
- [ ] Optionally: re-run the workflow on the same SHA and confirm it skips (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)