### PR TITLE
Reserve concurrency on CloudWatch Logs ingester Lambdas

### DIFF
--- a/ingest/aws/cloudwatch/logs/cloudformation/ingest-and-iam-onboarding.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/ingest-and-iam-onboarding.yaml
@@ -92,6 +92,15 @@ Parameters:
     MinValue: 128
     MaxValue: 10240
 
+  LambdaReservedConcurrency:
+    Type: Number
+    Description: >-
+      Reserved concurrent executions for the ingester Lambda. Caps parallel
+      invocations so the function cannot exhaust the account-wide Lambda
+      concurrency budget.
+    Default: 50
+    MinValue: 1
+
   LogRetentionDays:
     Type: Number
     Description: >-
@@ -191,6 +200,7 @@ Resources:
             !If [HasBasicAuth, !Ref FiretigerPassword, !Ref "AWS::NoValue"]
       Timeout: !Ref LambdaTimeoutSeconds
       MemorySize: !Ref LambdaMemorySizeMb
+      ReservedConcurrentExecutions: !Ref LambdaReservedConcurrency
       Architectures:
         - x86_64
       LoggingConfig:
@@ -232,6 +242,7 @@ Resources:
       Handler: index.lambda_handler
       Role: !GetAtt SubscriptionFilterManagerRole.Arn
       Timeout: 300
+      ReservedConcurrentExecutions: 2
       Code:
         S3Bucket: !Sub "firetiger-public-${AWS::Region}"
         S3Key: ingest/aws/cloudwatch/logs/lambda/filter_manager.zip

--- a/ingest/aws/cloudwatch/logs/cloudformation/template.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/template.yaml
@@ -65,6 +65,15 @@ Parameters:
     MinValue: 128
     MaxValue: 10240
 
+  LambdaReservedConcurrency:
+    Type: Number
+    Description: >-
+      Reserved concurrent executions for the ingester Lambda. Caps parallel
+      invocations so the function cannot exhaust the account-wide Lambda
+      concurrency budget.
+    Default: 50
+    MinValue: 1
+
   LogRetentionDays:
     Type: Number
     Description: >-
@@ -163,6 +172,7 @@ Resources:
             !If [HasBasicAuth, !Ref FiretigerPassword, !Ref "AWS::NoValue"]
       Timeout: !Ref LambdaTimeoutSeconds
       MemorySize: !Ref LambdaMemorySizeMb
+      ReservedConcurrentExecutions: !Ref LambdaReservedConcurrency
       Architectures:
         - x86_64
       LoggingConfig:
@@ -204,6 +214,7 @@ Resources:
       Handler: index.lambda_handler
       Role: !GetAtt SubscriptionFilterManagerRole.Arn
       Timeout: 300
+      ReservedConcurrentExecutions: 2
       Code:
         S3Bucket: !Sub "firetiger-public-${AWS::Region}"
         S3Key: ingest/aws/cloudwatch/logs/lambda/filter_manager.zip

--- a/ingest/aws/cloudwatch/logs/terraform/main.tf
+++ b/ingest/aws/cloudwatch/logs/terraform/main.tf
@@ -76,6 +76,8 @@ resource "aws_lambda_function" "cloudwatch_logs_ingester" {
   memory_size   = var.lambda_memory_size_mb
   architectures = ["x86_64"]
 
+  reserved_concurrent_executions = var.lambda_reserved_concurrency
+
   s3_bucket        = data.aws_s3_bucket.lambda_code_bucket.bucket
   s3_key           = "ingest/aws/cloudwatch/logs/lambda/ingester.zip"
   source_code_hash = data.aws_s3_object.lambda_code.etag

--- a/ingest/aws/cloudwatch/logs/terraform/variables.tf
+++ b/ingest/aws/cloudwatch/logs/terraform/variables.tf
@@ -49,10 +49,21 @@ variable "lambda_memory_size_mb" {
   type        = number
   description = "Lambda function memory size in MB"
   default     = 256
-  
+
   validation {
     condition     = var.lambda_memory_size_mb >= 128 && var.lambda_memory_size_mb <= 10240
     error_message = "Lambda memory size must be between 128 and 10240 MB."
+  }
+}
+
+variable "lambda_reserved_concurrency" {
+  type        = number
+  description = "Reserved concurrent executions for the ingester Lambda. Caps parallel invocations so the function cannot exhaust the account-wide concurrency budget."
+  default     = 50
+
+  validation {
+    condition     = var.lambda_reserved_concurrency >= 1
+    error_message = "Reserved concurrency must be a positive integer."
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a `LambdaReservedConcurrency` parameter (CloudFormation) / `lambda_reserved_concurrency` variable (Terraform) on the CloudWatch Logs ingester Lambda — default **50**, minimum **1**.
- Wires `ReservedConcurrentExecutions` / `reserved_concurrent_executions` into the ingester in all three deployable surfaces: the Terraform module, `cloudformation/template.yaml`, and `cloudformation/ingest-and-iam-onboarding.yaml`.
- Pins the internal subscription-filter-manager Lambda to a fixed reservation of 2 (it only runs on stack lifecycle events).

## Motivation
Without a reservation, a log-volume spike on subscribed log groups can let the ingester consume the customer's account-wide Lambda concurrency pool (default 1000, with only 100 unreserved) and starve other functions. The cap is set, not optional — there is no disable path.

## Test plan
- [ ] `terraform validate` passes in `ingest/aws/cloudwatch/logs/terraform/` (verified locally).
- [ ] Both CloudFormation templates parse and each `AWS::Lambda::Function` carries `ReservedConcurrentExecutions` (verified locally).
- [ ] Deploy one of the CloudFormation templates and confirm the ingester Lambda shows reserved concurrency = 50 in the console.
- [ ] Override `LambdaReservedConcurrency` to a different value at stack-create time and confirm it applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)