### PR TITLE
fix(ci): prefix tag SHA with 'g' so version is valid SemVer

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -24,8 +24,15 @@ jobs:
         run: |
           DATE=$(date -u +%Y.%-m.%-d)
           SHA=$(git rev-parse --short=7 "$GITHUB_SHA")
-          VERSION="${DATE}-${SHA}"
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+          # Prefix SHA with 'g' (git describe convention) so the prerelease
+          # identifier is never purely numeric — SemVer 2.0 disallows leading
+          # zeros in numeric identifiers, and 7-hex SHAs like 0873564 collide
+          # with that rule.
+          VERSION="${DATE}-g${SHA}"
+          # Require the prerelease block to contain at least one letter or
+          # hyphen so a purely-numeric identifier (which may have a leading
+          # zero) cannot slip through.
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-zA-Z.-]*[a-zA-Z-][0-9a-zA-Z.-]*)?$'; then
             echo "::error::Computed version '$VERSION' is not valid SemVer"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Mirrors the fix from [firetiger-inc/core#5956](https://github.com/firetiger-inc/core/pull/5956), which caught this bug live on `main` when the `publish-chart` job blew up on `chart.metadata.version "2026.5.18-0873564" is invalid`.

- **Bug:** SemVer 2.0 forbids leading zeros in purely-numeric prerelease identifiers. A 7-hex SHA like `0873564` (all digits, leading zero) produces a tag like `2026.5.18-0873564` that fails strict SemVer parsing — e.g. Terraform's `version = "..."` constraint syntax, or any release tool that consumes the tag as a SemVer version
- **Latent here**, not actively failing: tags are currently used as git refs (`?ref=<tag>` for Terraform module pinning), where SemVer rules don't apply
- **Fix:** prefix the SHA with `g` (the `git describe` convention) so the prerelease identifier is always alphanumeric. New tags look like `2026.5.18-g0873564`
- **Also:** tighten the validator regex to actually catch the bug it claims to guard against. The previous regex `^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$` accepts purely-numeric prereleases — false sense of safety

## Test plan

- [ ] Workflow's `Compute version` step runs green
- [ ] Tag is created in the form `YYYY.M.D-gXXXXXXX`
- [ ] Terraform module pin example in the workflow summary continues to work — the tag is still a valid git ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)