### PR TITLE
feat: make IAM role name prefix configurable

### DIFF
--- a/ingest/aws/cloudwatch/logs/README.md
+++ b/ingest/aws/cloudwatch/logs/README.md
@@ -141,6 +141,7 @@ us-east-1, us-east-2, us-west-1, us-west-2, ca-central-1, eu-west-1, eu-west-2, 
 - `lambda_timeout_seconds` / `LambdaTimeoutSeconds` - Lambda timeout in seconds (default: 300)
 - `lambda_memory_size_mb` / `LambdaMemorySizeMb` - Lambda memory in MB (default: 256)
 - `log_retention_days` / `LogRetentionDays` - Lambda log retention (default: 7)
+- `iam_role_prefix` / `IamRolePrefix` - Optional prefix prepended to all IAM role names (default: empty, i.e. names based on `name_prefix` / the stack name). Include any separator yourself, e.g. `"my-org-"`. Useful when your account enforces an IAM role naming convention or permission-boundary path requirement.
 
 ## Log Group Patterns
 

--- a/ingest/aws/cloudwatch/logs/README.md
+++ b/ingest/aws/cloudwatch/logs/README.md
@@ -141,7 +141,7 @@ us-east-1, us-east-2, us-west-1, us-west-2, ca-central-1, eu-west-1, eu-west-2, 
 - `lambda_timeout_seconds` / `LambdaTimeoutSeconds` - Lambda timeout in seconds (default: 300)
 - `lambda_memory_size_mb` / `LambdaMemorySizeMb` - Lambda memory in MB (default: 256)
 - `log_retention_days` / `LogRetentionDays` - Lambda log retention (default: 7)
-- `iam_role_prefix` / `IamRolePrefix` - Optional prefix prepended to all IAM role names (default: empty, i.e. names based on `name_prefix` / the stack name). Include any separator yourself, e.g. `"my-org-"`. Useful when your account enforces an IAM role naming convention or permission-boundary path requirement.
+- `iam_role_name_prefix` / `IamRoleNamePrefix` - Optional prefix prepended to all IAM role names (default: empty, i.e. names based on `name_prefix` / the stack name). Include any separator yourself, e.g. `"my-org-"`. Useful when your account enforces an IAM role naming convention or permission-boundary path requirement.
 
 ## Log Group Patterns
 

--- a/ingest/aws/cloudwatch/logs/cloudformation/iam-only.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/iam-only.yaml
@@ -30,6 +30,17 @@ Parameters:
       Multiple policies can be combined for broader access.
     Default: "arn:aws:iam::aws:policy/ReadOnlyAccess"
 
+  IamRolePrefix:
+    Type: String
+    Description: >-
+      Optional prefix prepended to the name of the IAM role created by this
+      template. Leave empty to keep the default name (based on the stack name).
+      Include any desired separator in the value (e.g. "my-org-"). Useful when
+      your account enforces an IAM role naming convention or permission-boundary
+      path requirement. The full role ARN is reported in the stack Outputs, so
+      the prefix does not affect Firetiger onboarding.
+    Default: ""
+
 # ==============================================================================
 # Resources
 # ==============================================================================
@@ -38,7 +49,7 @@ Resources:
   FiretigerAccessRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}@FiretigerAccessRole"
+      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}@FiretigerAccessRole"
       Description: "Cross-account role for Firetiger to access AWS resources"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/ingest/aws/cloudwatch/logs/cloudformation/iam-only.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/iam-only.yaml
@@ -30,7 +30,7 @@ Parameters:
       Multiple policies can be combined for broader access.
     Default: "arn:aws:iam::aws:policy/ReadOnlyAccess"
 
-  IamRolePrefix:
+  IamRoleNamePrefix:
     Type: String
     Description: >-
       Optional prefix prepended to the name of the IAM role created by this
@@ -49,7 +49,7 @@ Resources:
   FiretigerAccessRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}@FiretigerAccessRole"
+      RoleName: !Sub "${IamRoleNamePrefix}${AWS::StackName}@FiretigerAccessRole"
       Description: "Cross-account role for Firetiger to access AWS resources"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/ingest/aws/cloudwatch/logs/cloudformation/ingest-and-iam-onboarding.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/ingest-and-iam-onboarding.yaml
@@ -133,6 +133,18 @@ Parameters:
         3653,
       ]
 
+  IamRolePrefix:
+    Type: String
+    Description: >-
+      Optional prefix prepended to the names of all IAM roles created by this
+      template (including the cross-account FiretigerAccessRole). Leave empty to
+      keep the default names (based on the stack name). Include any desired
+      separator in the value (e.g. "my-org-"). Useful when your account enforces
+      an IAM role naming convention or permission-boundary path requirement.
+      The full role ARN is reported in the stack Outputs, so the prefix does not
+      affect Firetiger onboarding.
+    Default: ""
+
 # ==============================================================================
 # Conditions
 # ==============================================================================
@@ -142,6 +154,7 @@ Conditions:
     - !Not [!Equals [!Ref FiretigerUsername, ""]]
     - !Not [!Equals [!Ref FiretigerPassword, ""]]
   ShouldCreateIAMRole: !Equals [!Ref CreateFiretigerAccessRole, "true"]
+  HasIamRolePrefix: !Not [!Equals [!Ref IamRolePrefix, ""]]
 
 # ==============================================================================
 # Resources
@@ -152,7 +165,7 @@ Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-lambda-execution-role"
+      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}-lambda-execution-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -251,6 +264,10 @@ Resources:
   SubscriptionFilterManagerRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !If
+        - HasIamRolePrefix
+        - !Sub "${IamRolePrefix}${AWS::StackName}-subscription-filter-manager-role"
+        - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -284,7 +301,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: ShouldCreateIAMRole
     Properties:
-      RoleName: !Sub "${AWS::StackName}@FiretigerAccessRole"
+      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}@FiretigerAccessRole"
       Description: "Cross-account role for Firetiger to access AWS resources (read-only)"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/ingest/aws/cloudwatch/logs/cloudformation/ingest-and-iam-onboarding.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/ingest-and-iam-onboarding.yaml
@@ -133,7 +133,7 @@ Parameters:
         3653,
       ]
 
-  IamRolePrefix:
+  IamRoleNamePrefix:
     Type: String
     Description: >-
       Optional prefix prepended to the names of all IAM roles created by this
@@ -154,7 +154,7 @@ Conditions:
     - !Not [!Equals [!Ref FiretigerUsername, ""]]
     - !Not [!Equals [!Ref FiretigerPassword, ""]]
   ShouldCreateIAMRole: !Equals [!Ref CreateFiretigerAccessRole, "true"]
-  HasIamRolePrefix: !Not [!Equals [!Ref IamRolePrefix, ""]]
+  HasIamRoleNamePrefix: !Not [!Equals [!Ref IamRoleNamePrefix, ""]]
 
 # ==============================================================================
 # Resources
@@ -165,7 +165,7 @@ Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}-lambda-execution-role"
+      RoleName: !Sub "${IamRoleNamePrefix}${AWS::StackName}-lambda-execution-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -265,8 +265,8 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !If
-        - HasIamRolePrefix
-        - !Sub "${IamRolePrefix}${AWS::StackName}-subscription-filter-manager-role"
+        - HasIamRoleNamePrefix
+        - !Sub "${IamRoleNamePrefix}${AWS::StackName}-subscription-filter-manager-role"
         - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -301,7 +301,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: ShouldCreateIAMRole
     Properties:
-      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}@FiretigerAccessRole"
+      RoleName: !Sub "${IamRoleNamePrefix}${AWS::StackName}@FiretigerAccessRole"
       Description: "Cross-account role for Firetiger to access AWS resources (read-only)"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/ingest/aws/cloudwatch/logs/cloudformation/template.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/template.yaml
@@ -106,7 +106,7 @@ Parameters:
         3653,
       ]
 
-  IamRolePrefix:
+  IamRoleNamePrefix:
     Type: String
     Description: >-
       Optional prefix prepended to the names of all IAM roles created by this
@@ -125,7 +125,7 @@ Conditions:
     - !Not [!Equals [!Ref FiretigerUsername, ""]]
     - !Not [!Equals [!Ref FiretigerPassword, ""]]
 
-  HasIamRolePrefix: !Not [!Equals [!Ref IamRolePrefix, ""]]
+  HasIamRoleNamePrefix: !Not [!Equals [!Ref IamRoleNamePrefix, ""]]
 
 # ==============================================================================
 # Resources
@@ -136,7 +136,7 @@ Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}-lambda-execution-role"
+      RoleName: !Sub "${IamRoleNamePrefix}${AWS::StackName}-lambda-execution-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -236,8 +236,8 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !If
-        - HasIamRolePrefix
-        - !Sub "${IamRolePrefix}${AWS::StackName}-subscription-filter-manager-role"
+        - HasIamRoleNamePrefix
+        - !Sub "${IamRoleNamePrefix}${AWS::StackName}-subscription-filter-manager-role"
         - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/ingest/aws/cloudwatch/logs/cloudformation/template.yaml
+++ b/ingest/aws/cloudwatch/logs/cloudformation/template.yaml
@@ -106,6 +106,16 @@ Parameters:
         3653,
       ]
 
+  IamRolePrefix:
+    Type: String
+    Description: >-
+      Optional prefix prepended to the names of all IAM roles created by this
+      template. Leave empty to keep the default names (based on the stack name).
+      Include any desired separator in the value (e.g. "my-org-"). Useful when
+      your account enforces an IAM role naming convention or permission-boundary
+      path requirement.
+    Default: ""
+
 # ==============================================================================
 # Conditions
 # ==============================================================================
@@ -114,6 +124,8 @@ Conditions:
   HasBasicAuth: !And
     - !Not [!Equals [!Ref FiretigerUsername, ""]]
     - !Not [!Equals [!Ref FiretigerPassword, ""]]
+
+  HasIamRolePrefix: !Not [!Equals [!Ref IamRolePrefix, ""]]
 
 # ==============================================================================
 # Resources
@@ -124,7 +136,7 @@ Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-lambda-execution-role"
+      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}-lambda-execution-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -223,6 +235,10 @@ Resources:
   SubscriptionFilterManagerRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !If
+        - HasIamRolePrefix
+        - !Sub "${IamRolePrefix}${AWS::StackName}-subscription-filter-manager-role"
+        - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/ingest/aws/cloudwatch/logs/terraform/main.tf
+++ b/ingest/aws/cloudwatch/logs/terraform/main.tf
@@ -29,7 +29,7 @@ data "aws_s3_bucket" "lambda_code_bucket" {
 # ==============================================================================
 
 resource "aws_iam_role" "lambda_execution_role" {
-  name = "${var.iam_role_prefix}${var.name_prefix}-lambda-execution-role"
+  name = "${var.iam_role_name_prefix}${var.name_prefix}-lambda-execution-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/ingest/aws/cloudwatch/logs/terraform/main.tf
+++ b/ingest/aws/cloudwatch/logs/terraform/main.tf
@@ -29,7 +29,7 @@ data "aws_s3_bucket" "lambda_code_bucket" {
 # ==============================================================================
 
 resource "aws_iam_role" "lambda_execution_role" {
-  name = "${var.name_prefix}-lambda-execution-role"
+  name = "${var.iam_role_prefix}${var.name_prefix}-lambda-execution-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/ingest/aws/cloudwatch/logs/terraform/variables.tf
+++ b/ingest/aws/cloudwatch/logs/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "name_prefix" {
   default     = "firetiger-cloudwatch-logs"
 }
 
+variable "iam_role_prefix" {
+  type        = string
+  description = "Optional prefix prepended to the names of IAM roles created by this module. Leave empty to keep the default names (based on name_prefix). Include any desired separator in the value (e.g. \"my-org-\"). Useful when your account enforces an IAM role naming convention or permission-boundary path requirement."
+  default     = ""
+}
+
 variable "firetiger_endpoint" {
   type        = string
   description = "Firetiger OpenTelemetry logs endpoint (e.g., https://ingest.my-deployment.firetigerapi.com)"

--- a/ingest/aws/cloudwatch/logs/terraform/variables.tf
+++ b/ingest/aws/cloudwatch/logs/terraform/variables.tf
@@ -4,7 +4,7 @@ variable "name_prefix" {
   default     = "firetiger-cloudwatch-logs"
 }
 
-variable "iam_role_prefix" {
+variable "iam_role_name_prefix" {
   type        = string
   description = "Optional prefix prepended to the names of IAM roles created by this module. Leave empty to keep the default names (based on name_prefix). Include any desired separator in the value (e.g. \"my-org-\"). Useful when your account enforces an IAM role naming convention or permission-boundary path requirement."
   default     = ""

--- a/ingest/aws/ecs/events/README.md
+++ b/ingest/aws/ecs/events/README.md
@@ -61,7 +61,7 @@ aws cloudformation create-stack \
 - `event_pattern` / `EventPattern` - EventBridge rule pattern (default: STOPPED tasks)
 - `invocation_rate_per_second` / `InvocationRatePerSecond` - Rate limit (default: 1)
 - `enable_dead_letter_queue` / `EnableDeadLetterQueue` - Enable DLQ (default: true)
-- `iam_role_prefix` / `IamRolePrefix` - Optional prefix prepended to all IAM role names (default: empty, i.e. names based on `name_prefix` / the stack name). Include any separator yourself, e.g. `"my-org-"`. Useful when your account enforces an IAM role naming convention or permission-boundary path requirement.
+- `iam_role_name_prefix` / `IamRoleNamePrefix` - Optional prefix prepended to all IAM role names (default: empty, i.e. names based on `name_prefix` / the stack name). Include any separator yourself, e.g. `"my-org-"`. Useful when your account enforces an IAM role naming convention or permission-boundary path requirement.
 
 ## Event Patterns
 

--- a/ingest/aws/ecs/events/README.md
+++ b/ingest/aws/ecs/events/README.md
@@ -61,6 +61,7 @@ aws cloudformation create-stack \
 - `event_pattern` / `EventPattern` - EventBridge rule pattern (default: STOPPED tasks)
 - `invocation_rate_per_second` / `InvocationRatePerSecond` - Rate limit (default: 1)
 - `enable_dead_letter_queue` / `EnableDeadLetterQueue` - Enable DLQ (default: true)
+- `iam_role_prefix` / `IamRolePrefix` - Optional prefix prepended to all IAM role names (default: empty, i.e. names based on `name_prefix` / the stack name). Include any separator yourself, e.g. `"my-org-"`. Useful when your account enforces an IAM role naming convention or permission-boundary path requirement.
 
 ## Event Patterns
 

--- a/ingest/aws/ecs/events/cloudformation/template.yaml
+++ b/ingest/aws/ecs/events/cloudformation/template.yaml
@@ -65,6 +65,16 @@ Parameters:
     Description: "EventBridge bus to use (default or custom bus name)"
     Default: "default"
 
+  IamRolePrefix:
+    Type: String
+    Description: >-
+      Optional prefix prepended to the names of all IAM roles created by this
+      template. Leave empty to keep the default names (based on the stack name).
+      Include any desired separator in the value (e.g. "my-org-"). Useful when
+      your account enforces an IAM role naming convention or permission-boundary
+      path requirement.
+    Default: ""
+
 # ==============================================================================
 # Conditions
 # ==============================================================================
@@ -126,7 +136,7 @@ Resources:
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-eventbridge-role"
+      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}-eventbridge-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/ingest/aws/ecs/events/cloudformation/template.yaml
+++ b/ingest/aws/ecs/events/cloudformation/template.yaml
@@ -65,7 +65,7 @@ Parameters:
     Description: "EventBridge bus to use (default or custom bus name)"
     Default: "default"
 
-  IamRolePrefix:
+  IamRoleNamePrefix:
     Type: String
     Description: >-
       Optional prefix prepended to the names of all IAM roles created by this
@@ -136,7 +136,7 @@ Resources:
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${IamRolePrefix}${AWS::StackName}-eventbridge-role"
+      RoleName: !Sub "${IamRoleNamePrefix}${AWS::StackName}-eventbridge-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/ingest/aws/ecs/events/terraform/main.tf
+++ b/ingest/aws/ecs/events/terraform/main.tf
@@ -61,7 +61,7 @@ resource "aws_cloudwatch_event_api_destination" "firetiger_api_destination" {
 # ==============================================================================
 
 resource "aws_iam_role" "eventbridge_role" {
-  name                 = "${var.name_prefix}-ecs-task-state-role"
+  name                 = "${var.iam_role_prefix}${var.name_prefix}-ecs-task-state-role"
   permissions_boundary = var.iam_permissions_boundary_arn
 
   assume_role_policy = jsonencode({

--- a/ingest/aws/ecs/events/terraform/main.tf
+++ b/ingest/aws/ecs/events/terraform/main.tf
@@ -61,7 +61,7 @@ resource "aws_cloudwatch_event_api_destination" "firetiger_api_destination" {
 # ==============================================================================
 
 resource "aws_iam_role" "eventbridge_role" {
-  name                 = "${var.iam_role_prefix}${var.name_prefix}-ecs-task-state-role"
+  name                 = "${var.iam_role_name_prefix}${var.name_prefix}-ecs-task-state-role"
   permissions_boundary = var.iam_permissions_boundary_arn
 
   assume_role_policy = jsonencode({

--- a/ingest/aws/ecs/events/terraform/variables.tf
+++ b/ingest/aws/ecs/events/terraform/variables.tf
@@ -4,7 +4,7 @@ variable "name_prefix" {
   default     = "firetiger-eventbridge-ecs"
 }
 
-variable "iam_role_prefix" {
+variable "iam_role_name_prefix" {
   type        = string
   description = "Optional prefix prepended to the names of IAM roles created by this module. Leave empty to keep the default names (based on name_prefix). Include any desired separator in the value (e.g. \"my-org-\"). Useful when your account enforces an IAM role naming convention or permission-boundary path requirement."
   default     = ""

--- a/ingest/aws/ecs/events/terraform/variables.tf
+++ b/ingest/aws/ecs/events/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "name_prefix" {
   default     = "firetiger-eventbridge-ecs"
 }
 
+variable "iam_role_prefix" {
+  type        = string
+  description = "Optional prefix prepended to the names of IAM roles created by this module. Leave empty to keep the default names (based on name_prefix). Include any desired separator in the value (e.g. \"my-org-\"). Useful when your account enforces an IAM role naming convention or permission-boundary path requirement."
+  default     = ""
+}
+
 variable "firetiger_endpoint" {
   type        = string
   description = "Firetiger ingest server endpoint (e.g., https://ingest.my-deployment.firetigerapi.com)"


### PR DESCRIPTION
## Summary

Adds an optional, prepended prefix for **all** provisioned IAM role names, across both CloudFormation and Terraform. Defaults to empty — existing deployments keep identical names, so this is fully backward-compatible.

The motivating use case: accounts that enforce an IAM role naming convention or permission-boundary path requirement via SCPs.

## Behavior

- New input on both stacks (same concept, idiomatic name each): `IamRolePrefix` (CloudFormation) / `iam_role_prefix` (Terraform), default `""`.
- The prefix is **prepended** to the existing name; the stack name / `name_prefix` portion is kept: `${IamRolePrefix}${AWS::StackName}-lambda-execution-role`.
- You include any separator yourself (e.g. `"my-org-"`).

## Roles covered

**CloudFormation**
- `cloudwatch/logs/template.yaml` — `LambdaExecutionRole`; `SubscriptionFilterManagerRole` (had no explicit name — gets a prefixed name **only when** the prefix is set, otherwise keeps CloudFormation's auto-generated name, so no replacement on existing stacks).
- `cloudwatch/logs/ingest-and-iam-onboarding.yaml` — Lambda role, filter-manager role, and the cross-account `FiretigerAccessRole`.
- `cloudwatch/logs/iam-only.yaml` — `FiretigerAccessRole`.
- `ecs/events/template.yaml` — `EventBridgeRole`.

**Terraform**
- `cloudwatch/logs/terraform` — `lambda_execution_role`.
- `ecs/events/terraform` — `eventbridge_role`.

## Notes

- The cross-account role keeps its `@FiretigerAccessRole` suffix. Onboarding uses the full role ARN from stack outputs, so the prefix does **not** break Firetiger's role discovery (called out in the parameter description).
- Changing the prefix on an existing stack renames roles (new ARN) and forces replacement — fine for fresh deploys; for the cross-account role you'd re-copy the new ARN into Firetiger.
- Scoped to IAM **role** names only — inline role policy names and non-IAM resource names are untouched.
- Validated: all four CF templates parse with the new parameter; `terraform fmt` clean on edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)